### PR TITLE
Added decimal support, changed implementation syntax

### DIFF
--- a/event-listener.js
+++ b/event-listener.js
@@ -34,8 +34,15 @@ var inputHandler = exports.inputHandler = function inputHandler(ev) {
 };
 
 var maskInput = function maskInput(mask, input) {
-  if (mask === 'money') {
-    input.value = _vanillaMasker2.default.toMoney(input.value, { showSignal: true });
+  if (mask.mask === 'money') {
+    if (Number.isInteger(input.value)) {
+      input.value = _vanillaMasker2.default.toMoney(input.value, { showSignal: true });
+    } else {
+      input.value = _vanillaMasker2.default.toMoney(parseFloat(input.value).toFixed(mask.precision), {
+        precision: mask.precision,
+        showSignal: true
+      });
+    }
   } else {
     input.value = mask && mask.length > 0 ? _vanillaMasker2.default.toPattern(input.value, mask) : input.value;
   }

--- a/index.js
+++ b/index.js
@@ -19,7 +19,14 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var applyMaskToDefault = function applyMaskToDefault(el, mask, isMoney) {
   var inputText = getInputText(el);
   if (isMoney && inputText.value.length > 0) {
-    inputText.value = _vanillaMasker2.default.toMoney(inputText.value, { showSignal: true });
+    if (Number.isInteger(inputText.value)) {
+      inputText.value = _vanillaMasker2.default.toMoney(inputText.value, { showSignal: true });
+    } else {
+      inputText.value = _vanillaMasker2.default.toMoney(parseFloat(inputText.value).toFixed(mask.precision), {
+        precision: mask.precision,
+        showSignal: true
+      });
+    }
   } else {
     inputText.value = mask && mask.length > 0 ? _vanillaMasker2.default.toPattern(inputText.value, mask) : inputText.value;
   }
@@ -40,7 +47,7 @@ exports.default = {
     if (binding.value.length < 1) return;
     var inputText = getInputText(el);
     inputText.setAttribute('data-mask', binding.value);
-    if (binding.value === 'money') {
+    if (binding.value.mask === 'money') {
       isMoney = true;
     } else {
       var maskSize = inputText.getAttribute('data-mask').length;
@@ -53,7 +60,7 @@ exports.default = {
     // this is only for v-model
     if (binding.value.length < 1) return;
     var inputText = getInputText(el);
-    if (binding.value === 'money') {
+    if (binding.value.mask === 'money') {
       applyMaskToDefault(inputText, binding.value, true);
       return;
     }

--- a/src/event-listener.js
+++ b/src/event-listener.js
@@ -24,8 +24,15 @@ export const inputHandler = (ev) => {
 }
 
 let maskInput = (mask, input) => {
-  if(mask === 'money'){
-    input.value = VMasker.toMoney(input.value, {showSignal: true});
+  if (mask.mask === 'money') {
+    if (Number.isInteger(input.value)) {
+      input.value = VMasker.toMoney(input.value, {showSignal: true});
+    } else {
+      input.value = VMasker.toMoney(parseFloat(input.value).toFixed(mask.precision), {
+        precision: mask.precision,
+        showSignal: true
+      });
+    }
   } else {
     input.value = mask && mask.length > 0 ? VMasker.toPattern(input.value, mask) : input.value
   }

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,14 @@ import { inputHandler } from './event-listener'
 let applyMaskToDefault = (el, mask, isMoney) => {
   const inputText = getInputText(el);
   if(isMoney && inputText.value.length > 0){
-    inputText.value = VMasker.toMoney(inputText.value, {showSignal: true});
+    if (Number.isInteger(inputText.value)) {
+      inputText.value = VMasker.toMoney(inputText.value, {showSignal: true});
+    } else {
+      inputText.value = VMasker.toMoney(parseFloat(inputText.value).toFixed(mask.precision), {
+        precision: mask.precision,
+        showSignal: true
+      });
+    }
   } else {
     inputText.value = mask && mask.length > 0 ? VMasker.toPattern(inputText.value, mask) : inputText.value
   }
@@ -28,7 +35,7 @@ export default {
     if(binding.value.length < 1) return
     const inputText = getInputText(el);
     inputText.setAttribute('data-mask', binding.value)
-    if(binding.value === 'money'){
+    if(binding.value.mask === 'money'){
       isMoney = true;
     } else {
       let maskSize = inputText.getAttribute('data-mask').length
@@ -41,7 +48,7 @@ export default {
     // this is only for v-model
     if(binding.value.length < 1) return
     const inputText = getInputText(el);
-    if(binding.value === 'money'){
+    if(binding.value.mask === 'money'){
       applyMaskToDefault(inputText ,binding.value, true)
       return
     }


### PR DESCRIPTION
With this new decimal support the implementation of money mask that was:

```vue
<input v-model="price" v-mask="'money'"/>
```

Should be now:
```vue
<template>
   <input v-model="price" v-mask="money"/>
</template>
<script>
   [...]
   export default {
      data () {
         return {
            price: null,
            money: {
               mask: 'money',
               precision: 2 // defines the number of zeroes after the decimal separator
            }
         }
      }
   }
</script>
```